### PR TITLE
Fix license badge issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Twitter bot bootstrap
 
-[![Standard - JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](http://standardjs.com/)
-[![license](https://img.shields.io/github/license/mashape/apistatus.svg)](http://opensource.org/licenses/MIT)
+[![Standard - JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](http://standardjs.com/) [![license](https://img.shields.io/github/license/mashape/apistatus.svg)](http://opensource.org/licenses/MIT)
 
 This is a bootstrap for setting up a Twitter bot with Node.js using the `twit` library. The bot will favorite and retweet what you specify when configuring it. It will also reply to followers with a selection of canned responses.
 


### PR DESCRIPTION
Like you mentioned in issue #11, the license badge image wouldn't load consistently. For me, it was just a regular link about 75% of the time. I put both badges on the same line with just a space in between and it appears to have fixed the issue for me.